### PR TITLE
speculative fix: send Opower-Selected-Entities header to fix ConEd 424

### DIFF
--- a/sensors/measure_electricity_usage
+++ b/sensors/measure_electricity_usage
@@ -9,6 +9,7 @@ import aiohttp
 import pyotp
 import pyjson5
 import os
+import json
 import traceback
 
 config = None
@@ -107,6 +108,9 @@ async def internal_get_realtime_usage_data():
     customer_uuid_url = 'https://cned.opower.com/ei/edge/apis/multi-account-v1/cws/cned/customers/current'
     customer_info = await get_response(customer_uuid_url)
     customer_uuid = customer_info['utilityAccounts'][0]['uuid']
+
+    # Required since ~Dec 2025 by the cws-real-time-ami-v1 endpoints; otherwise they return 424.
+    login_headers['Opower-Selected-Entities'] = json.dumps([f'urn:opower:customer:uuid:{customer_uuid}'])
 
     # Another URL is returns account info also. Not sure which is better to use. See:
     # https://github.com/tronikos/opower/blob/79ca62203932c065b9d282184ea6f9df6d32128f/src/opower/opower.py#L364


### PR DESCRIPTION
## Summary
- Since late Dec 2025, `measure_electricity_usage` has been failing with `424 Failed Dependency` on `GET /cws-real-time-ami-v1/cws/cned/accounts/<uuid>/meters`.
- Upstream `tronikos/opower` sends an `Opower-Selected-Entities` header (a JSON array containing `urn:opower:customer:uuid:<customer_uuid>`) on this endpoint; our script never did. ConEd appears to have started enforcing it.
- Fix: set that header on `login_headers` immediately after fetching `customer_uuid`, so both the `/meters` and `/meters/<id>/usage` calls carry it.

## Why "speculative"
End-to-end verification from this laptop kept tripping ConEd auth/abuse heuristics (OAuth callback returns a "500 ERROR" page with cookies whose `expires=` is exactly 1 year in the past, dropping them from the jar; subsequent retries got 403'd). The fix is verified logically with a mock-based test that confirms the header is now set on `/meters` and `/usage` and is *not* set before `customer_uuid` is known. Real-world verification needs to happen on the Pi.

## Test plan
- [ ] Pull on the Pi, restart `measure_electricity_usage`, and watch the next 5-minute scrape.
- [ ] Confirm the 424 is gone and `electricity_kwh` data resumes flowing into Prometheus.