### PR TITLE
Switch ConEd realtime usage fetch to GraphQL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 *.db
 *.db.bak
 config.json
+# HAR captures may contain bearer tokens, session cookies, and account UUIDs.
+*.har
+HAR.json

--- a/sensors/measure_electricity_usage
+++ b/sensors/measure_electricity_usage
@@ -105,43 +105,131 @@ async def internal_get_realtime_usage_data():
     authorization_token = await get_response(power_token_url)
     login_headers['authorization'] = 'Bearer ' + authorization_token
 
-    customer_uuid_url = 'https://cned.opower.com/ei/edge/apis/multi-account-v1/cws/cned/customers/current'
-    customer_info = await get_response(customer_uuid_url)
-    customer_uuid = customer_info['utilityAccounts'][0]['uuid']
-
-    # Required since ~Dec 2025 by the cws-real-time-ami-v1 endpoints; otherwise they return 424.
+    customer_url = 'https://cned.opower.com/ei/edge/apis/multi-account-v1/cws/cned/customers/current'
+    customer_info = await get_response(customer_url)
+    customer_uuid = customer_info['uuid']
     login_headers['Opower-Selected-Entities'] = json.dumps([f'urn:opower:customer:uuid:{customer_uuid}'])
 
-    # Another URL is returns account info also. Not sure which is better to use. See:
-    # https://github.com/tronikos/opower/blob/79ca62203932c065b9d282184ea6f9df6d32128f/src/opower/opower.py#L364
-    account_url = f'https://cned.opower.com/ei/edge/apis/cws-real-time-ami-v1/cws/cned/accounts/{customer_uuid}/meters'
-    account_info = await get_response(account_url)
-    account_id = account_info['meters_ids'][0]
+    # The realtime endpoint /cws-real-time-ami-v1/.../accounts/<uuid>/meters has been broken
+    # since ~Dec 2025 (HTTP 424, EDAP returns no meter asset id;
+    # https://github.com/tronikos/opower/issues/180). The ConEd web app sidesteps it by
+    # using the GraphQL API instead. Same data, no EDAP dependency.
+    return await fetch_via_graphql()
 
-    realtime_usage_url = f'https://cned.opower.com/ei/edge/apis/cws-real-time-ami-v1/cws/cned/accounts/{customer_uuid}/meters/{account_id}/usage'
-    realtime_usage = await get_response(realtime_usage_url)
-    realtime_usage = realtime_usage['reads']
+GRAPHQL_URL = 'https://cned.opower.com/ei/edge/apis/dsm-graphql-v1/cws/graphql'
 
-    return format_realtime_usage(realtime_usage)
+# Operation names match what the ConEd web app sends. Servers in this stack often log /
+# rate-limit by operationName, so it's worth keeping them recognizable.
+WBAS_BILLING_ACCOUNTS_QUERY = '''
+query WBAS_BillingAccounts($first: Int, $onlyActive: Boolean) {
+  billingAccountsConnection(first: $first) {
+    edges { node {
+      urn
+      serviceAgreementsConnection(first: 10, onlyActive: $onlyActive) {
+        edges { node { uuid serviceType
+          servicePointsConnection { edges { node { uuid serviceType } } }
+        } }
+      }
+    } }
+  }
+}
+'''
 
-# input: something that looks like this: https://gist.github.com/dasl-/4c6da56ecc9e6ee1cf89f7a05dd45cb2
-def format_realtime_usage(realtime_usage):
-    readings = list(filter(lambda read: read['value'] is not None, realtime_usage))
+WRTAMI_GET_REGISTERS_QUERY = '''
+query WRTAMI_GetRegisters($selectedAccount: ID, $saUuid: String, $spUuid: String) {
+  billingAccountByAuthContext(selectedAccount: $selectedAccount) {
+    serviceAgreementsConnection(onlyActive: true, matching: $saUuid) {
+      edges { node {
+        servicePointsConnection(matching: $spUuid) {
+          edges { node {
+            intervalReads(units: [KWH], serviceQuantityIdentifier: [NET_USAGE], onlyUnverifiedStreams: true) {
+              registerId
+            }
+          } }
+        }
+      } }
+    }
+  }
+}
+'''
 
-    # Readings are taken every 15m. Get the last 24 hours of readings, in case con ed's website
-    # had an extended outage and we have to  catch up. It appears that the API only provides the last
-    # 24 hours of readings anyway.
-    latest_readings = readings[-96:]
-    formatted_readings = []
+# WRTAMI_GetRegisterUsage caps each request at a 24-hour window. Without an explicit
+# timeInterval the server returns the most recent ~24h.
+WRTAMI_GET_REGISTER_USAGE_QUERY = '''
+query WRTAMI_GetRegisterUsage($selectedAccount: ID, $registerId: ID, $saUuid: String, $spUuid: String) {
+  billingAccountByAuthContext(selectedAccount: $selectedAccount) {
+    serviceAgreementsConnection(onlyActive: true, matching: $saUuid) {
+      edges { node {
+        servicePointsConnection(matching: $spUuid) {
+          edges { node {
+            intervalReads(registerId: $registerId, units: [KWH], serviceQuantityIdentifier: [NET_USAGE], onlyUnverifiedStreams: true) {
+              reads { timeInterval measuredAmount { value } }
+            }
+          } }
+        }
+      } }
+    }
+  }
+}
+'''
 
-    for read in latest_readings:
-        dt = datetime.datetime.fromisoformat(read['startTime'])
-        unix_time_ms = int(round(dt.timestamp()))
-        if not unix_time_ms:
+async def post_graphql(operation_name, query, variables):
+    body = {'operationName': operation_name, 'query': query, 'variables': variables}
+    async with session.post(GRAPHQL_URL, json=body, headers=login_headers, timeout=15) as response:
+        if response.status != 200:
+            raise Exception(f'GraphQL HTTP {response.status} for {operation_name}: {await response.text()}')
+        result = await response.json()
+    if 'errors' in result:
+        raise Exception(f'GraphQL errors for {operation_name}: {result["errors"]}')
+    return result['data']
+
+async def fetch_via_graphql():
+    accounts = await post_graphql('WBAS_BillingAccounts', WBAS_BILLING_ACCOUNTS_QUERY,
+                                  {'first': 25, 'onlyActive': True})
+    edges = accounts['billingAccountsConnection']['edges']
+    if not edges:
+        raise Exception('GraphQL returned no billing accounts')
+    node = edges[0]['node']
+    account_urn = node['urn']
+    sa = next(x['node'] for x in node['serviceAgreementsConnection']['edges']
+              if x['node']['serviceType'] == 'ELECTRICITY')
+    sp = next(x['node'] for x in sa['servicePointsConnection']['edges']
+              if x['node']['serviceType'] == 'ELECTRICITY')
+
+    registers = await post_graphql('WRTAMI_GetRegisters', WRTAMI_GET_REGISTERS_QUERY,
+                                   {'selectedAccount': account_urn, 'saUuid': sa['uuid'], 'spUuid': sp['uuid']})
+    interval_reads = (registers['billingAccountByAuthContext']
+                               ['serviceAgreementsConnection']['edges'][0]['node']
+                               ['servicePointsConnection']['edges'][0]['node']
+                               ['intervalReads'])
+    if not interval_reads:
+        raise Exception('GraphQL WRTAMI_GetRegisters returned no intervalReads')
+    register_id = interval_reads[0]['registerId']
+
+    usage = await post_graphql('WRTAMI_GetRegisterUsage', WRTAMI_GET_REGISTER_USAGE_QUERY,
+                               {'selectedAccount': account_urn, 'registerId': register_id,
+                                'saUuid': sa['uuid'], 'spUuid': sp['uuid']})
+    reads = (usage['billingAccountByAuthContext']
+                  ['serviceAgreementsConnection']['edges'][0]['node']
+                  ['servicePointsConnection']['edges'][0]['node']
+                  ['intervalReads'][0]['reads'])
+    return format_realtime_usage(reads)
+
+# Each read looks like:
+#   {"timeInterval": "2026-04-29T01:15:00Z/2026-04-29T01:30:00Z",
+#    "measuredAmount": {"value": 0.177}}
+# Returns (kwh, unix_seconds) tuples for the latest 24h (96 quarter-hour slots).
+def format_realtime_usage(reads):
+    valid = [r for r in reads if r.get('measuredAmount') is not None]
+    formatted = []
+    for read in valid[-96:]:
+        start_iso = read['timeInterval'].split('/', 1)[0]
+        dt = datetime.datetime.fromisoformat(start_iso.replace('Z', '+00:00'))
+        unix_seconds = int(round(dt.timestamp()))
+        if not unix_seconds:
             raise Exception('Unable to parse timestamp from response')
-        formatted_readings.append((float(read['value']), unix_time_ms))
-
-    return formatted_readings
+        formatted.append((float(read['measuredAmount']['value']), unix_seconds))
+    return formatted
 
 async def post_response(url, data = None, json = None, timeout = 10, as_json = True):
     async with session.post(

--- a/sensors/measure_electricity_usage
+++ b/sensors/measure_electricity_usage
@@ -44,7 +44,10 @@ def setup_prometheus():
 
 async def get_realtime_usage_data():
     global session
-    session = aiohttp.ClientSession()
+    # Session-level total timeout is a backstop: every individual request below
+    # also sets its own (smaller) timeout, but if a future call forgets to,
+    # this caps the wait at 30s instead of aiohttp's default 5min.
+    session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
     try:
         return await internal_get_realtime_usage_data()
     except Exception as e:
@@ -62,8 +65,11 @@ async def get_realtime_usage_data():
 # https://github.com/dasl-/pitools/blob/e66a6ededab5272c3d24c40d9a523385466ec8ef/sensors/measure_electricity_usage
 async def internal_get_realtime_usage_data():
     global login_headers
-    # Double-logins are somewhat broken if cookies stay around.
-    # Let's clear everything except device tokens (which allow skipping 2FA)
+    # No-op under the current design: get_realtime_usage_data() creates a fresh
+    # ClientSession on every scrape, so the cookie jar is always empty here.
+    # Kept as a guardrail for any future shift back to a persistent session:
+    # drop stale coned.com cookies but keep CE_DEVICE_ID, which lets ConEd skip
+    # 2FA on a recognized device.
     session.cookie_jar.clear(
         lambda cookie: cookie["domain"] == "www.coned.com"
         and cookie.key != "CE_DEVICE_ID"
@@ -240,7 +246,7 @@ async def post_response(url, data = None, json = None, timeout = 10, as_json = T
         json = json,
         headers = login_headers,
         allow_redirects=True,
-        timeout = 10
+        timeout = timeout
     ) as response:
         if response.status != 200:
             raise Exception(f'Got unexpected status code {response.status} for url: {url}')

--- a/sensors/measure_electricity_usage
+++ b/sensors/measure_electricity_usage
@@ -187,8 +187,8 @@ async def fetch_via_graphql():
     accounts = await post_graphql('WBAS_BillingAccounts', WBAS_BILLING_ACCOUNTS_QUERY,
                                   {'first': 25, 'onlyActive': True})
     edges = accounts['billingAccountsConnection']['edges']
-    if not edges:
-        raise Exception('GraphQL returned no billing accounts')
+    if len(edges) != 1:
+        raise Exception(f'expected exactly 1 billing account, got {len(edges)}')
     node = edges[0]['node']
     account_urn = node['urn']
     sa = next(x['node'] for x in node['serviceAgreementsConnection']['edges']
@@ -220,14 +220,16 @@ async def fetch_via_graphql():
 #    "measuredAmount": {"value": 0.177}}
 # Returns (kwh, unix_seconds) tuples for the latest 24h (96 quarter-hour slots).
 def format_realtime_usage(reads):
-    valid = [r for r in reads if r.get('measuredAmount') is not None]
+    valid = [r for r in reads
+             if r.get('measuredAmount') is not None
+             and r['measuredAmount'].get('value') is not None]
     formatted = []
     for read in valid[-96:]:
         start_iso = read['timeInterval'].split('/', 1)[0]
         dt = datetime.datetime.fromisoformat(start_iso.replace('Z', '+00:00'))
+        if dt.tzinfo is None:
+            raise Exception(f'unexpected naive timestamp from response: {start_iso!r}')
         unix_seconds = int(round(dt.timestamp()))
-        if not unix_seconds:
-            raise Exception('Unable to parse timestamp from response')
         formatted.append((float(read['measuredAmount']['value']), unix_seconds))
     return formatted
 

--- a/sensors/measure_electricity_usage
+++ b/sensors/measure_electricity_usage
@@ -110,10 +110,10 @@ async def internal_get_realtime_usage_data():
     customer_uuid = customer_info['uuid']
     login_headers['Opower-Selected-Entities'] = json.dumps([f'urn:opower:customer:uuid:{customer_uuid}'])
 
-    # The realtime endpoint /cws-real-time-ami-v1/.../accounts/<uuid>/meters has been broken
-    # since ~Dec 2025 (HTTP 424, EDAP returns no meter asset id;
-    # https://github.com/tronikos/opower/issues/180). The ConEd web app sidesteps it by
-    # using the GraphQL API instead. Same data, no EDAP dependency.
+    # The realtime endpoint /cws-real-time-ami-v1/.../accounts/<uuid>/meters has been
+    # broken for our account since ~Dec 2025 (HTTP 424; sometimes 404). See
+    # https://github.com/tronikos/opower/issues/180. The ConEd web app sidesteps the
+    # issue by using the GraphQL API instead. Same data, no dependency on the broken path.
     return await fetch_via_graphql()
 
 GRAPHQL_URL = 'https://cned.opower.com/ei/edge/apis/dsm-graphql-v1/cws/graphql'


### PR DESCRIPTION
## Summary

The `/cws-real-time-ami-v1/.../accounts/<uuid>/meters` REST endpoint has been broken for our account since late Dec 2025: HTTP 424 (and sometimes 404) because an internal ConEd backend stopped returning meter asset IDs for rotated account UUIDs. See [tronikos/opower#180](https://github.com/tronikos/opower/issues/180).

The ConEd web app continues to render realtime data because it doesn't use that endpoint — it queries `dsm-graphql-v1` instead. This PR matches that approach:

```
WBAS_BillingAccounts     -> account_urn, serviceAgreement uuid, servicePoint uuid
WRTAMI_GetRegisters      -> registerId for the (sa, sp) pair
WRTAMI_GetRegisterUsage  -> 24h of 15-min KWH reads (NET_USAGE)
```

GraphQL bypasses the broken path entirely. Operation names and query shapes were captured from a HAR of the browser hitting `coned.com/.../energy-use`.

Also fixes a pre-existing bug in the `Opower-Selected-Entities` header value: it was set to `utilityAccounts[0].uuid` (an *account* uuid) but the header expects the *customer* uuid (`customer.uuid` at the top level of the `customers/current` response). With the realtime endpoint broken, this misuse never surfaced; now that we're hitting GraphQL, it could.

## Endpoint comparison

| Endpoint | Latency | 15-min retention | Status |
|---|---|---|---|
| `cws-real-time-ami-v1/.../usage` (legacy REST) | ~1h | ~24h only | ❌ 424 since Dec 2025 |
| `dsm-graphql-v1` `WRTAMI_GetRegisterUsage` (this PR) | ~50min | 6+ years (verified) | ✅ |
| `DataBrowser-v1/.../reads` | ~13h | ~3 years | ✅ but stale |

GraphQL caps each request at 24h, which is exactly what we want — the existing collector already takes the most recent 24h × 4 = 96 quarter-hour slots.

## Test plan

- [x] Live verified against the production account: 92 valid quarter-hour reads, KWh values match what the ConEd web app shows. Latest read ~50min behind realtime.
- [ ] Pull on `study`, restart `measure_electricity_usage`, confirm 5-min Prometheus scrape resumes populating `electricity_kwh` and journalctl no longer logs `Got unexpected status code 424`.

## Note

Includes a tiny `.gitignore` companion commit that ignores `*.har` / `HAR.json`. Browser HAR captures contain bearer tokens, cookies, and account UUIDs and shouldn't be committed.